### PR TITLE
Feature/dynamics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Run with in-memory database for testing:
 launches/serverctl run --spring.profiles.active=h2
 ```
 
+Run with the mock CRM endpoint for automated testing:
+```bash
+launches/serverctl run --spring.profiles.active=mock-crm
+```
+
 ## Verifying changes
 
 To run unit and integration tests:

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <classifier>testcommons</classifier>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>adal4j</artifactId>
+            <version>1.6.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/defra/datareturns/RcrApi.java
+++ b/src/main/java/uk/gov/defra/datareturns/RcrApi.java
@@ -2,6 +2,7 @@ package uk.gov.defra.datareturns;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 /**
  * Application class for the Rod catch returns API
@@ -9,6 +10,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author Sam Gardner-Dell
  */
 @SpringBootApplication
+@EnableCaching
 @SuppressWarnings({"checkstyle:HideUtilityClassConstructor", "NonFinalUtilityClass"})
 public class RcrApi {
     /**

--- a/src/main/java/uk/gov/defra/datareturns/RcrApi.java
+++ b/src/main/java/uk/gov/defra/datareturns/RcrApi.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
- * Application class for the Data Returns PI submissions API.
+ * Application class for the Rod catch returns API
  *
  * @author Sam Gardner-Dell
  */

--- a/src/main/java/uk/gov/defra/datareturns/config/AADConfiguration.java
+++ b/src/main/java/uk/gov/defra/datareturns/config/AADConfiguration.java
@@ -1,0 +1,31 @@
+package uk.gov.defra.datareturns.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Configuration options for Microsoft Azure active directory authenticating authority
+ *
+ * @author Sam Gardner-Dell
+ */
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "active-directory")
+@Getter
+@Setter
+@Validated
+public class AADConfiguration {
+    private URI tenant;
+    private URL authority;
+    private String clientId;
+    private String clientSecret;
+}
+

--- a/src/main/java/uk/gov/defra/datareturns/config/DynamicsConfiguration.java
+++ b/src/main/java/uk/gov/defra/datareturns/config/DynamicsConfiguration.java
@@ -1,0 +1,46 @@
+package uk.gov.defra.datareturns.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+
+/**
+ * Configuration options for Microsoft Dynamics integration
+ *
+ * @author Sam Gardner-Dell
+ */
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "dynamics")
+@Getter
+@Setter
+@Validated
+public class DynamicsConfiguration {
+    /**
+     * The service implementation to use - supported values are 'dynamics' and 'mock'
+     */
+    @NotNull
+    private DynamicsImpl impl;
+
+    /**
+     * The dynamics endpoint
+     */
+    private URI endpoint;
+
+    public enum DynamicsImpl {
+        /**
+         * the configured dynamics endpoint will be queried
+         */
+        DYNAMICS,
+        /**
+         * no connectivity to dynamics - mock data will be used
+         */
+        MOCK
+    }
+}

--- a/src/main/java/uk/gov/defra/datareturns/config/DynamicsConfiguration.java
+++ b/src/main/java/uk/gov/defra/datareturns/config/DynamicsConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.net.URL;
 
 /**
  * Configuration options for Microsoft Dynamics integration
@@ -31,7 +32,12 @@ public class DynamicsConfiguration {
     /**
      * The dynamics endpoint
      */
-    private URI endpoint;
+    private URL endpoint;
+
+    /**
+     * The dynamics endpoint
+     */
+    private URI api;
 
     public enum DynamicsImpl {
         /**

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
@@ -27,7 +27,7 @@ public class Contact implements CRMEntity {
     @JsonProperty("Postcode")
     private String postcode;
 
-    @JsonProperty("PermissionNumber")
+    @JsonProperty("ReturnPermissionNumber")
     private String permissionNumber;
 
     @JsonProperty("ReturnStatus")

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
@@ -1,8 +1,12 @@
 package uk.gov.defra.datareturns.data.model.licences;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
+import uk.gov.defra.datareturns.services.crm.CRMEntity;
 
 /**
  * Represents a contact entry within the CRM
@@ -11,14 +15,24 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-public class Contact {
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Contact implements CRMEntity {
     /**
      * the id associated with the contact
      */
+    @JsonProperty("ContactId")
     private String id;
 
-    /**
-     * the postcode associated with the contact
-     */
+    @JsonProperty("Postcode")
     private String postcode;
+
+    @JsonProperty("PermissionNumber")
+    private String permissionNumber;
+
+    @JsonProperty("ReturnStatus")
+    private String returnStatus;
+
+    @JsonProperty("ErrorMessage")
+    private String errorMessage;
 }

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/Contact.java
@@ -1,0 +1,24 @@
+package uk.gov.defra.datareturns.data.model.licences;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a contact entry within the CRM
+ *
+ * @author Sam Gardner-Dell
+ */
+@Getter
+@Setter
+public class Contact {
+    /**
+     * the id associated with the contact
+     */
+    private String id;
+
+    /**
+     * the postcode associated with the contact
+     */
+    private String postcode;
+}

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/Licence.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/Licence.java
@@ -1,0 +1,23 @@
+package uk.gov.defra.datareturns.data.model.licences;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a licence entry within the CRM
+ *
+ * @author Sam Gardner-Dell
+ */
+@Getter
+@Setter
+public class Licence {
+    /**
+     * The full licence number
+     */
+    private String licenceNumber;
+
+    /**
+     * The contact record associated with the licence
+     */
+    private Contact contact;
+}

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import springfox.documentation.annotations.ApiIgnore;
 import uk.gov.defra.datareturns.services.crm.CrmLookupService;
 
+import java.io.IOException;
+
 /**
  * Controller to enable the lookup of licence information from the CRM
  *
@@ -32,25 +34,25 @@ public class LicenceController implements ResourceProcessor<RepositoryLinksResou
     private final CrmLookupService lookupService;
 
     /**
-     * Retrieve a licence based on the given (partial) licence number
+     * Retrieve a contact based on the given (partial) licence number
      *
      * @param licenceNumber the licence number used to retrieve licence information
      * @return a {@link ResponseEntity} containing the target {@link Licence} or a 404 status if not found
      * @throws IOException on error
      */
-    @GetMapping(value = "/licences/{licence}")
-    public ResponseEntity<?> getLicence(@PathVariable("licence") final String licenceNumber) {
-        final Licence licence = lookupService.getLicence(licenceNumber);
-        if (licence != null) {
-            return new ResponseEntity<>(licence, HttpStatus.OK);
+    @GetMapping(value = "/contact/{licence}")
+    public ResponseEntity<Contact> getContact(@PathVariable("licence") final String licenceNumber) {
+        final Contact contact = lookupService.getContactFromLicence(licenceNumber);
+        if (contact == null || contact.getReturnStatus().endsWith("error")) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(contact, HttpStatus.OK);
     }
 
     /**
      * @return 405, "Method Not Allowed"
      */
-    @RequestMapping(method = {RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.POST, RequestMethod.DELETE}, value = "/licences/*")
+    @RequestMapping(method = {RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.POST, RequestMethod.DELETE}, value = "/contact/*")
     @ApiIgnore
     public ResponseEntity<Licence> disabledMethods() {
         return new ResponseEntity<>(HttpStatus.METHOD_NOT_ALLOWED);

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
@@ -1,0 +1,67 @@
+package uk.gov.defra.datareturns.data.model.licences;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import springfox.documentation.annotations.ApiIgnore;
+import uk.gov.defra.datareturns.services.crm.CrmLookupService;
+
+import java.io.IOException;
+
+/**
+ * Controller to enable the lookup of licence information from the CRM
+ *
+ * @author Sam Gardner-Dell
+ */
+@BasePathAwareController
+@ConditionalOnWebApplication
+@Slf4j
+@RequiredArgsConstructor
+public class LicenceController implements ResourceProcessor<RepositoryLinksResource> {
+    /**
+     * the service used to lookup licence data
+     */
+    private final CrmLookupService lookupService;
+
+    /**
+     * Retrieve a licence based on the given (partial) licence number
+     *
+     * @param licenceNumber the licence number used to retrieve licence information
+     * @return a {@link ResponseEntity} containing the target {@link Licence} or a 404 status if not found
+     * @throws IOException on error
+     */
+    @GetMapping(value = "/licences/{licence}")
+    public ResponseEntity<?> getLicence(@PathVariable("licence") final String licenceNumber) {
+        final Licence licence = lookupService.getLicence(licenceNumber);
+        if (licence != null) {
+            return new ResponseEntity<>(licence, HttpStatus.OK);
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * @return 405, "Method Not Allowed"
+     */
+    @RequestMapping(method = {RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.POST, RequestMethod.DELETE}, value = "/licences/*")
+    @ApiIgnore
+    public ResponseEntity<Licence> disabledMethods() {
+        return new ResponseEntity<>(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    public RepositoryLinksResource process(final RepositoryLinksResource resource) {
+        // TODO: Base path should be preprended to href
+        resource.add(new Link("/licences", "licences"));
+        return resource;
+    }
+}

--- a/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
+++ b/src/main/java/uk/gov/defra/datareturns/data/model/licences/LicenceController.java
@@ -16,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import springfox.documentation.annotations.ApiIgnore;
 import uk.gov.defra.datareturns.services.crm.CrmLookupService;
 
-import java.io.IOException;
-
 /**
  * Controller to enable the lookup of licence information from the CRM
  *

--- a/src/main/java/uk/gov/defra/datareturns/services/aad/TokenService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/aad/TokenService.java
@@ -1,0 +1,10 @@
+package uk.gov.defra.datareturns.services.aad;
+
+/**
+ * Service to retrieve access token from Azure active directory
+ *
+ * @author Graham Willis
+ */
+public interface TokenService {
+    String getToken();
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/aad/TokenServiceImpl.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/aad/TokenServiceImpl.java
@@ -1,0 +1,109 @@
+package uk.gov.defra.datareturns.services.aad;
+
+
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import com.microsoft.aad.adal4j.AuthenticationContext;
+import com.microsoft.aad.adal4j.AuthenticationResult;
+import com.microsoft.aad.adal4j.ClientCredential;
+import com.microsoft.aad.adal4j.AuthenticationCallback;
+import uk.gov.defra.datareturns.config.AADConfiguration;
+import uk.gov.defra.datareturns.config.DynamicsConfiguration;
+
+import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.TimerTask;
+import java.util.concurrent.*;
+/**
+ * Service to retrieve access token from Azure active directory
+ *
+ * @author Graham Willis
+ */
+@Service
+@Slf4j
+public class TokenServiceImpl implements TokenService {
+    @Inject
+    private TokenServiceImpl proxy;
+
+    @Inject
+    AADConfiguration aadConfiguration;
+
+    @Inject
+    DynamicsConfiguration dynamicsConfiguration;
+
+    @Override
+    @Cacheable(cacheNames = "crm-auth-token")
+    public String getToken() {
+        ExecutorService service = Executors.newFixedThreadPool(1);
+        try {
+            URI tenant = aadConfiguration.getTenant();
+            URL authority = aadConfiguration.getAuthority();
+            URL tokenPath = new URL(authority, tenant.toString());
+            log.debug("Attempting to fetch AAD token from " + tokenPath);
+
+            String clientId = aadConfiguration.getClientId();
+            String clientSecret = aadConfiguration.getClientSecret();
+
+            URL resource = dynamicsConfiguration.getEndpoint();
+
+            // Generate a credentials payload from the clientId and secret
+            ClientCredential clientCredential = new ClientCredential(clientId, clientSecret);
+
+            AuthenticationContext context = new AuthenticationContext(tokenPath.toString(), true, service);
+
+            // Attempt to acquire a token and fire the callback defined below
+            Future<AuthenticationResult> future = context.acquireToken(resource.toString(),
+                    clientCredential, new Callback());
+
+            // Return the token as a string
+            AuthenticationResult token = future.get();
+            String accessToken = token.getAccessToken();
+            return accessToken;
+        } catch (MalformedURLException|InterruptedException|ExecutionException e) {
+            log.error("Error fetching token: " + e.getMessage());
+        } finally {
+            service.shutdown();
+        }
+        return null;
+    }
+
+    /**
+     * Token acquire callback
+     */
+    private class Callback implements AuthenticationCallback<AuthenticationResult> {
+        public void onSuccess(AuthenticationResult result) {
+            /**
+             * Success: execute a timer to evict the token from the cache before it expires
+             */
+            long seconds = result.getExpiresAfter();
+            log.debug("AAD token acquired successfully: expires in " + seconds + " seconds");
+            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+            // Remove the token 1 minute before it is due to expire
+            long delay  = Math.max(seconds - 60, 0);
+            executor.schedule(new TimerTask() {
+                public void run() {
+                    proxy.evictToken();
+                }
+            }, delay, TimeUnit.SECONDS);
+            executor.shutdown();
+        }
+
+        public void onFailure(Throwable throwable) {
+            log.error("Failed to acquire token from AAD: " + throwable.toString());
+        }
+    }
+
+    /**
+     * Evict the token from the cache
+     */
+    @CacheEvict(cacheNames = "crm-auth-token", allEntries = true)
+    public void evictToken() {
+        log.debug("Evicting AAD token from cache");
+    }
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/aad/TokenServiceImpl.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/aad/TokenServiceImpl.java
@@ -1,7 +1,5 @@
 package uk.gov.defra.datareturns.services.aad;
 
-
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/CRMEntity.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/CRMEntity.java
@@ -1,0 +1,4 @@
+package uk.gov.defra.datareturns.services.crm;
+
+public interface CRMEntity {
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
@@ -1,7 +1,6 @@
 package uk.gov.defra.datareturns.services.crm;
 
 import uk.gov.defra.datareturns.data.model.licences.Contact;
-import uk.gov.defra.datareturns.data.model.licences.Licence;
 
 /**
  * Service to retrieve contact details from the CRM
@@ -9,14 +8,6 @@ import uk.gov.defra.datareturns.data.model.licences.Licence;
  * @author Sam Gardner-Dell
  */
 public interface CrmLookupService {
-
-    /**
-     * Retrieve a licence for the given lookup string (usually the last 6 digits of the licence number)
-     *
-     * @param lookup the lookup string (usually the last 6 digits of the licence number)
-     * @return the {@link Licence} object for the given lookup string or null if not found
-     */
-    Licence getLicence(String lookup);
 
     /**
      * Retrieve a contact for the given contact id

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
@@ -25,4 +25,11 @@ public interface CrmLookupService {
      * @return the {@link Contact} object for the given contact id or null if not found
      */
     Contact getContact(String contactId);
+
+    /**
+     * Retrieve the contact details using the last 6 digits of the licence number
+     * @param licenceNumber
+     * @return
+     */
+    Contact getContactFromLicence(String licenceNumber);
 }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/CrmLookupService.java
@@ -1,0 +1,28 @@
+package uk.gov.defra.datareturns.services.crm;
+
+import uk.gov.defra.datareturns.data.model.licences.Contact;
+import uk.gov.defra.datareturns.data.model.licences.Licence;
+
+/**
+ * Service to retrieve contact details from the CRM
+ *
+ * @author Sam Gardner-Dell
+ */
+public interface CrmLookupService {
+
+    /**
+     * Retrieve a licence for the given lookup string (usually the last 6 digits of the licence number)
+     *
+     * @param lookup the lookup string (usually the last 6 digits of the licence number)
+     * @return the {@link Licence} object for the given lookup string or null if not found
+     */
+    Licence getLicence(String lookup);
+
+    /**
+     * Retrieve a contact for the given contact id
+     *
+     * @param contactId the contact id used to retrieve the {@link Contact} object
+     * @return the {@link Contact} object for the given contact id or null if not found
+     */
+    Contact getContact(String contactId);
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -1,14 +1,27 @@
 package uk.gov.defra.datareturns.services.crm;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.defra.datareturns.config.DynamicsConfiguration;
 import uk.gov.defra.datareturns.data.model.licences.Contact;
 import uk.gov.defra.datareturns.data.model.licences.Licence;
+import uk.gov.defra.datareturns.services.aad.TokenService;
+
+import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * Mock CRM lookup service
@@ -21,10 +34,19 @@ import uk.gov.defra.datareturns.data.model.licences.Licence;
 @Slf4j
 @RequiredArgsConstructor
 public class DynamicsCrmLookupService implements CrmLookupService {
+
+    //protected class DynamicsCrmStoredProcesdures {
+      //  protected final String GET_CONTACT_BY_LICENSE_NUMBER = "defra_ GetContactByLicenseNumber";
+    //}
+
     /**
      * the dynamics configuration
      */
+    @Inject
     private DynamicsConfiguration dynamicsConfiguration;
+
+    @Inject
+    private TokenService tokenService;
 
     @Override
     public Licence getLicence(final String lookup) {
@@ -41,5 +63,79 @@ public class DynamicsCrmLookupService implements CrmLookupService {
         contact.setId(contactId);
         contact.setPostcode("WA4 1AB");
         return contact;
+    }
+
+    @Override
+    public Contact getContactFromLicence(String licenceNumber) {
+        ContactQuery contactQuery = new ContactQuery();
+        contactQuery.query = contactQuery.new Query();
+        contactQuery.query.setPermissionNumber(licenceNumber);
+        Contact contact = callCRM(contactQuery);
+        return contact;
+    }
+
+    /**
+     * This interface defines classes that describe the artifacts needed
+     * to call a stored procedure on the CRM, that is the query parameters
+     * posted to the CRM in the payload, the stored procedure name and
+     * the resulting type - a class extending CRMEntity
+     * @param <T>
+     */
+    public interface CRMQuery<T extends CRMEntity> {
+        String getCRMStoredProcedureName();
+        CRMQuery.Query getQuery();
+        Class<T> getEntityClass();
+        interface Query {}
+    }
+
+    /**
+     * This Query is used to get the contact details from the licence number
+     */
+    @Getter
+    @Setter
+    public class ContactQuery implements CRMQuery<Contact> {
+        private final String cRMStoredProcedureName = "defra_GetContactByLicenseNumber";
+        private Query query;
+
+        public Class<Contact> getEntityClass() {
+            return Contact.class;
+        }
+
+        @Getter
+        @Setter
+        @ToString
+        public class Query implements CRMQuery.Query {
+            @JsonProperty("PermissionNumber")
+            private String permissionNumber;
+        }
+    }
+
+    /**
+     * Generic CRM call method - uses the spring rest template
+     * @param crmQuery
+     * @param <T>
+     * @return
+     */
+    public <T extends CRMEntity> T callCRM(CRMQuery<T> crmQuery) {
+        try {
+            URL url = new URL(dynamicsConfiguration.getEndpoint(),
+                    dynamicsConfiguration.getApi().toString() + "/" + crmQuery.getCRMStoredProcedureName());
+
+            String urlString = url.toString();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Authorization", "Bearer " + tokenService.getToken());
+            HttpEntity<CRMQuery.Query> entity = new HttpEntity<>(crmQuery.getQuery(), headers);
+            RestTemplate restTemplate = new RestTemplate();
+
+            return restTemplate.postForObject(
+                    urlString,
+                    entity, crmQuery.getEntityClass());
+
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -46,16 +46,6 @@ public class DynamicsCrmLookupService implements CrmLookupService {
 
     //TODO Implement
     @Override
-    public Licence getLicence(final String lookup) {
-        // FIXME: Fetch the licence data from dynamic (dynamicsConfiguration.getEndpoint())
-        final Licence licence = new Licence();
-        licence.setLicenceNumber("CCBBAA");
-        licence.setContact(getContact("0987654321"));
-        return licence;
-    }
-
-    //TODO Implement
-    @Override
     public Contact getContact(final String contactId) {
         final Contact contact = new Contact();
         contact.setId(contactId);

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -1,0 +1,45 @@
+package uk.gov.defra.datareturns.services.crm;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+import uk.gov.defra.datareturns.config.DynamicsConfiguration;
+import uk.gov.defra.datareturns.data.model.licences.Contact;
+import uk.gov.defra.datareturns.data.model.licences.Licence;
+
+/**
+ * Mock CRM lookup service
+ *
+ * @author Sam Gardner-Dell
+ */
+@Service
+@ConditionalOnProperty(name = "dynamics.impl", havingValue = "dynamics")
+@Scope(BeanDefinition.SCOPE_SINGLETON)
+@Slf4j
+@RequiredArgsConstructor
+public class DynamicsCrmLookupService implements CrmLookupService {
+    /**
+     * the dynamics configuration
+     */
+    private DynamicsConfiguration dynamicsConfiguration;
+
+    @Override
+    public Licence getLicence(final String lookup) {
+        // FIXME: Fetch the licence data from dynamic (dynamicsConfiguration.getEndpoint())
+        final Licence licence = new Licence();
+        licence.setLicenceNumber("CCBBAA");
+        licence.setContact(getContact("0987654321"));
+        return licence;
+    }
+
+    @Override
+    public Contact getContact(final String contactId) {
+        final Contact contact = new Contact();
+        contact.setId(contactId);
+        contact.setPostcode("WA4 1AB");
+        return contact;
+    }
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.defra.datareturns.config.DynamicsConfiguration;
 import uk.gov.defra.datareturns.data.model.licences.Contact;
-import uk.gov.defra.datareturns.data.model.licences.Licence;
 import uk.gov.defra.datareturns.services.aad.TokenService;
 
 import javax.inject.Inject;
@@ -36,13 +35,20 @@ import java.net.URL;
 public class DynamicsCrmLookupService implements CrmLookupService {
 
     /**
-     * the dynamics configuration
+     * The dynamics configuration
      */
-    @Inject
     private DynamicsConfiguration dynamicsConfiguration;
 
-    @Inject
+    /**
+     * The dynamics authentication token service
+     */
     private TokenService tokenService;
+
+    @Inject
+    public DynamicsCrmLookupService(DynamicsConfiguration dynamicsConfiguration, TokenService tokenService) {
+        this.dynamicsConfiguration = dynamicsConfiguration;
+        this.tokenService = tokenService;
+    }
 
     //TODO Implement
     @Override
@@ -58,8 +64,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
         ContactQuery contactQuery = new ContactQuery();
         contactQuery.query = contactQuery.new Query();
         contactQuery.query.setPermissionNumber(licenceNumber);
-        Contact contact = callCRM(contactQuery);
-        return contact;
+        return callCRM(contactQuery);
     }
 
     /**
@@ -81,7 +86,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
      */
     @Getter
     @Setter
-    public class ContactQuery implements CRMQuery<Contact> {
+    public static class ContactQuery implements CRMQuery<Contact> {
         private final String cRMStoredProcedureName = "defra_GetContactByLicenseNumber";
         private Query query;
 
@@ -104,7 +109,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
      * @param <T>
      * @return
      */
-    public <T extends CRMEntity> T callCRM(CRMQuery<T> crmQuery) {
+    private <T extends CRMEntity> T callCRM(CRMQuery<T> crmQuery) {
         try {
             URL url = new URL(dynamicsConfiguration.getEndpoint(),
                     dynamicsConfiguration.getApi().toString() + "/" + crmQuery.getCRMStoredProcedureName());

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -24,9 +24,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
- * Mock CRM lookup service
+ * CRM lookup service
  *
- * @author Sam Gardner-Dell
+ * @author Graham Willis
  */
 @Service
 @ConditionalOnProperty(name = "dynamics.impl", havingValue = "dynamics")
@@ -34,10 +34,6 @@ import java.net.URL;
 @Slf4j
 @RequiredArgsConstructor
 public class DynamicsCrmLookupService implements CrmLookupService {
-
-    //protected class DynamicsCrmStoredProcesdures {
-      //  protected final String GET_CONTACT_BY_LICENSE_NUMBER = "defra_ GetContactByLicenseNumber";
-    //}
 
     /**
      * the dynamics configuration
@@ -48,6 +44,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
     @Inject
     private TokenService tokenService;
 
+    //TODO Implement
     @Override
     public Licence getLicence(final String lookup) {
         // FIXME: Fetch the licence data from dynamic (dynamicsConfiguration.getEndpoint())
@@ -57,6 +54,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
         return licence;
     }
 
+    //TODO Implement
     @Override
     public Contact getContact(final String contactId) {
         final Contact contact = new Contact();

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/DynamicsCrmLookupService.java
@@ -62,8 +62,9 @@ public class DynamicsCrmLookupService implements CrmLookupService {
     @Override
     public Contact getContactFromLicence(String licenceNumber) {
         ContactQuery contactQuery = new ContactQuery();
-        contactQuery.query = contactQuery.new Query();
-        contactQuery.query.setPermissionNumber(licenceNumber);
+        ContactQuery.Query query = new ContactQuery.Query();
+        query.setPermissionNumber(licenceNumber);
+        contactQuery.setQuery(query);
         return callCRM(contactQuery);
     }
 
@@ -97,7 +98,7 @@ public class DynamicsCrmLookupService implements CrmLookupService {
         @Getter
         @Setter
         @ToString
-        public class Query implements CRMQuery.Query {
+        public static class Query implements CRMQuery.Query {
             @JsonProperty("PermissionNumber")
             private String permissionNumber;
         }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 import uk.gov.defra.datareturns.data.model.licences.Contact;
 import uk.gov.defra.datareturns.data.model.licences.Licence;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * Mock CRM lookup service
  *
@@ -21,24 +26,43 @@ import uk.gov.defra.datareturns.data.model.licences.Licence;
 @RequiredArgsConstructor
 public class MockCrmLookupService implements CrmLookupService {
 
-    @Override
-    public Licence getLicence(final String lookup) {
-        final Licence licence = new Licence();
-        licence.setLicenceNumber("AABBCC");
-        licence.setContact(getContact("1234567890"));
-        return licence;
+    private static final Map<String, Contact> licences = new HashMap<>();
+    private static Map<String, Contact> byContact;
+
+    static {
+        for (int i = 1; i <= 8; i++) {
+            Contact c = new Contact();
+            c.setPostcode(String.format("WA4 %dHT", i));
+            c.setId(String.format("f8e6ee6a-8fba-e811-a96c-000%d3ab9add5", i));
+            c.setReturnStatus("success");
+            licences.put(String.format("B7A7%d8", i), c);
+        }
+        byContact = licences.values()
+                .stream()
+                .collect(Collectors.toMap(Contact::getId, c -> c));
     }
 
     @Override
     public Contact getContact(final String contactId) {
-        final Contact contact = new Contact();
-        contact.setId(contactId);
-        contact.setPostcode("WA4 1AB");
-        return contact;
+        if (byContact.containsKey(contactId)) {
+            return byContact.get(contactId);
+        } else {
+            final Contact contact = new Contact();
+            contact.setReturnStatus("error");
+            contact.setErrorMessage("Contact not found");
+            return contact;
+        }
     }
 
     @Override
     public Contact getContactFromLicence(String licenceNumber) {
-        return null;
+        if (licences.containsKey(licenceNumber.toUpperCase().trim())) {
+            return licences.get(licenceNumber);
+        } else {
+            final Contact contact = new Contact();
+            contact.setReturnStatus("error");
+            contact.setErrorMessage("Contact not found");
+            return contact;
+        }
     }
 }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -36,4 +36,9 @@ public class MockCrmLookupService implements CrmLookupService {
         contact.setPostcode("WA4 1AB");
         return contact;
     }
+
+    @Override
+    public Contact getContactFromLicence(String licenceNumber) {
+        return null;
+    }
 }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -65,9 +65,4 @@ public class MockCrmLookupService implements CrmLookupService {
             return contact;
         }
     }
-
-    @Override
-    public Contact getContactFromLicence(String licenceNumber) {
-        return null;
-    }
 }

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -32,10 +32,14 @@ public class MockCrmLookupService implements CrmLookupService {
     static {
         for (int i = 1; i <= 8; i++) {
             Contact c = new Contact();
-            c.setPostcode(String.format("WA4 %dHT", i));
+            String permission = String.format("B7A7%d8", i);
+            String postcode = String.format("WA4 %dHT", i);
+            c.setPermissionNumber(permission);
+            c.setPostcode(postcode);
             c.setId(String.format("f8e6ee6a-8fba-e811-a96c-000%d3ab9add5", i));
             c.setReturnStatus("success");
-            licences.put(String.format("B7A7%d8", i), c);
+            licences.put(permission, c);
+            log.info("Mock licence: " + c);
         }
         byContact = licences.values()
                 .stream()

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -1,0 +1,39 @@
+package uk.gov.defra.datareturns.services.crm;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+import uk.gov.defra.datareturns.data.model.licences.Contact;
+import uk.gov.defra.datareturns.data.model.licences.Licence;
+
+/**
+ * Mock CRM lookup service
+ *
+ * @author Sam Gardner-Dell
+ */
+@Service
+@ConditionalOnProperty(name = "dynamics.impl", havingValue = "mock")
+@Scope(BeanDefinition.SCOPE_SINGLETON)
+@Slf4j
+@RequiredArgsConstructor
+public class MockCrmLookupService implements CrmLookupService {
+
+    @Override
+    public Licence getLicence(final String lookup) {
+        final Licence licence = new Licence();
+        licence.setLicenceNumber("AABBCC");
+        licence.setContact(getContact("1234567890"));
+        return licence;
+    }
+
+    @Override
+    public Contact getContact(final String contactId) {
+        final Contact contact = new Contact();
+        contact.setId(contactId);
+        contact.setPostcode("WA4 1AB");
+        return contact;
+    }
+}

--- a/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
+++ b/src/main/java/uk/gov/defra/datareturns/services/crm/MockCrmLookupService.java
@@ -7,10 +7,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import uk.gov.defra.datareturns.data.model.licences.Contact;
-import uk.gov.defra.datareturns.data.model.licences.Licence;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -27,7 +25,7 @@ import java.util.stream.Collectors;
 public class MockCrmLookupService implements CrmLookupService {
 
     private static final Map<String, Contact> licences = new HashMap<>();
-    private static Map<String, Contact> byContact;
+    private static final Map<String, Contact> byContact;
 
     static {
         for (int i = 1; i <= 8; i++) {

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -25,7 +25,14 @@ server:
 
 dynamics:
   impl: dynamics
-  endpoint:
+  endpoint: https://ea-fish-devsandbox.crm4.dynamics.com
+  api: api/data/v9.0
+
+active-directory:
+  tenant: Defra.onmicrosoft.com
+  authority: https://login.microsoftonline.com
+  clientId: ***REMOVED***
+  clientSecret: ***REMOVED***
 
 ---
 ###############################################################################

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -23,6 +23,10 @@ server:
   display-name: rcr_api
   port: 9580
 
+dynamics:
+  impl: dynamics
+  endpoint:
+
 ---
 ###############################################################################
 #

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -51,3 +51,4 @@ spring:
 # Enable liquibase migrations when running in-memory
 liquibase:
   enabled: true
+

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -25,14 +25,14 @@ server:
 
 dynamics:
   impl: dynamics
-  endpoint: https://ea-fish-devsandbox.crm4.dynamics.com
-  api: api/data/v9.0
+  endpoint:
+  api:
 
 active-directory:
-  tenant: Defra.onmicrosoft.com
-  authority: https://login.microsoftonline.com
-  clientId: ***REMOVED***
-  clientSecret: ***REMOVED***
+  tenant:
+  authority:
+  clientId:
+  clientSecret:
 
 ---
 ###############################################################################

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -52,3 +52,16 @@ spring:
 liquibase:
   enabled: true
 
+---
+###############################################################################
+#
+# Profile: mock-crm used used for front end unit tests
+#
+###############################################################################
+spring:
+  profiles: mock-crm
+
+dynamics:
+  impl: mock
+
+---

--- a/src/test/java/uk/gov/defra/datareturns/test/licence/TestLicenceLookup.java
+++ b/src/test/java/uk/gov/defra/datareturns/test/licence/TestLicenceLookup.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.datareturns.test.licence;
+
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.defra.datareturns.data.model.licences.Contact;
+import uk.gov.defra.datareturns.services.crm.MockCrmLookupService;
+import uk.gov.defra.datareturns.testcommons.framework.WebIntegrationTest;
+
+import javax.inject.Inject;
+
+/**
+ * Integration tests licence lookup
+ */
+@RunWith(SpringRunner.class)
+@WebIntegrationTest
+@Slf4j
+public class TestLicenceLookup {
+    @Inject
+    private MockCrmLookupService crmLookupService;
+
+    @Test
+    public void testLicenceLookupSucceds() {
+        Contact contact = crmLookupService.getContactFromLicence("B7A728");
+        Assertions.assertThat(contact.getReturnStatus()).isEqualToIgnoringCase("success");
+    }
+
+    @Test
+    public void testLicenceLookupFails() {
+        Contact contact = crmLookupService.getContactFromLicence("B9A72D8");
+        Assertions.assertThat(contact.getReturnStatus()).isEqualToIgnoringCase("error");
+    }
+}


### PR DESCRIPTION
Added the basic functionality for integration with the CRM. The endpoint being /contact/{licence} where licence is the last 6 characters of the licence number.

Notes:

(1) This endpoint does not integrate with the Spring data rest endpoints, it is standalone. It therefore does not appear in the ALPS or Swagger browsers. There may be a way to force this in, but its not critical at this point.

(2) I did not see any tests which operate at the HTTP level so I have not added any here. The tests really only run the mock CRM stub which is a bit of a redundant exercise.

(3) I added a new profile so that the travis job in the front end can call ./launches/serverctl run --spring.profiles.active=mock-crm,h2

So the bare bones are all in and we can easily add the activity interface and contact id lookup.