### PR TITLE
Added in constraint to disallow no-date and no-month flags for the la…

### DIFF
--- a/src/main/java/uk/gov/defra/datareturns/validation/catches/CatchValidator.java
+++ b/src/main/java/uk/gov/defra/datareturns/validation/catches/CatchValidator.java
@@ -28,6 +28,7 @@ public class CatchValidator extends AbstractConstraintValidator<ValidCatch, Catc
     private static final String PROPERTY_RELEASED = "released";
     private static final String PROPERTY_SPECIES = "species";
     private static final String PROPERTY_ACTIVITY = "activity";
+    private static final String PROPERTY_ONLY_MONTH = "onlyMonthRecorded";
 
     /**
      * Maximum possible mass of a salmon/sea trout (world record is about 48kg)
@@ -42,7 +43,8 @@ public class CatchValidator extends AbstractConstraintValidator<ValidCatch, Catc
     @Override
     public void initialize(final ValidCatch constraintAnnotation) {
         super.addChecks(this::checkActivity, this::checkDate, this::checkSpecies,
-                this::checkMass, this::checkMassValue, this::checkMassLimits, this::checkMethod, this::checkMethodPermissions, this::checkReleased);
+                this::checkMass, this::checkMassValue, this::checkMassLimits, this::checkMethod,
+                this::checkMethodPermissions, this::checkReleased, this::checkDefaultDateFlagConflict);
     }
 
     /**
@@ -82,6 +84,20 @@ public class CatchValidator extends AbstractConstraintValidator<ValidCatch, Catc
         if (dateCaught.isAfter(LocalDate.now())) {
             return handleError(context, "DATE_IN_FUTURE", PROPERTY_DATE_CAUGHT);
         }
+        return true;
+    }
+
+    /**
+     * Check that the only month flag is not set when the no date recorded flag is set. It is superfluous
+     * @param catchEntry the {@link Catch} to be validated
+     * @param context    the validator context
+     * @return true if valid, false otherwise
+     */
+    private boolean checkDefaultDateFlagConflict(final Catch catchEntry, final ConstraintValidatorContext context) {
+        if (catchEntry.isNoDateRecorded() && catchEntry.isOnlyMonthRecorded()) {
+            return handleError(context, "NO_DATE_RECORDED_WITH_ONLY_MONTH_RECORDED", PROPERTY_ONLY_MONTH);
+        }
+
         return true;
     }
 

--- a/src/test/java/uk/gov/defra/datareturns/test/catches/CatchTests.java
+++ b/src/test/java/uk/gov/defra/datareturns/test/catches/CatchTests.java
@@ -84,14 +84,6 @@ public class CatchTests {
     }
 
     @Test
-    public void testValidCatchWithDefaultDateFlags() {
-        testCatch.setNoDateRecorded(true);
-        testCatch.setOnlyMonthRecorded(true);
-        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
-        Assertions.assertThat(violations).isEmpty();
-    }
-
-    @Test
     public void testCatchWithoutDateFails() {
         testCatch.setDateCaught(null);
         final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
@@ -191,6 +183,13 @@ public class CatchTests {
     }
 
     @Test
+    public void testValidCatchWithNoDateRecorded() {
+        testCatch.setNoDateRecorded(true);
+        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
+        Assertions.assertThat(violations).isEmpty();
+    }
+
+    @Test
     public void testValidCatchWithOnlyMonthRecorded() {
         testCatch.setOnlyMonthRecorded(true);
         final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
@@ -198,25 +197,26 @@ public class CatchTests {
     }
 
     @Test
-    public void testValidCatchWithOnlyMonthRecordedAndNoDateSetFails() {
+    public void testCatchWithOnlyMonthRecordedAndNoDateRecordedFails() {
+        testCatch.setOnlyMonthRecorded(true);
+        testCatch.setNoDateRecorded(true);
+        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
+        Assertions.assertThat(violations).haveExactly(1, violationMessageMatching("CATCH_NO_DATE_RECORDED_WITH_ONLY_MONTH_RECORDED"));
+    }
+
+    @Test
+    public void testCatchWithNoDateRecordedAndNoDateSetFails() {
+        testCatch.setNoDateRecorded(true);
+        testCatch.setDateCaught(null);
+        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
+        Assertions.assertThat(violations).haveExactly(1, violationMessageMatching("CATCH_DEFAULT_DATE_REQUIRED"));
+    }
+
+    @Test
+    public void testCatchWithOnlyMonthRecordedAndNoDateSetFails() {
         testCatch.setOnlyMonthRecorded(true);
         testCatch.setDateCaught(null);
         final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
         Assertions.assertThat(violations).haveExactly(1, violationMessageMatching("CATCH_DEFAULT_DATE_REQUIRED"));
-    }
-
-    @Test
-    public void testValidCatchWithNoDateRecordedAndNoDateSetFails() {
-        testCatch.setNoDateRecorded(true);
-        testCatch.setDateCaught(null);
-        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
-        Assertions.assertThat(violations).haveExactly(1, violationMessageMatching("CATCH_DEFAULT_DATE_REQUIRED"));
-    }
-
-    @Test
-    public void testValidCatchWithNoDateRecorded() {
-        testCatch.setNoDateRecorded(true);
-        final Set<ConstraintViolation<Catch>> violations = validator.validate(testCatch);
-        Assertions.assertThat(violations).isEmpty();
     }
 }


### PR DESCRIPTION
The additional validation for null dates - cannot have no-date and no-month flags both set for large catches.