### PR TITLE
Upload artifacts to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         ]
                     ]) {
-                        s3 = defraS3('apsldnrcrsrv001')
+                        s3 = defraS3()
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@feature/iwtf-2874-s3-interface') _
+@Library('defra-shared@master') _
 def arti = defraArtifactory()
 def s3
 
@@ -55,7 +55,7 @@ pipeline {
         stage('Upload distribution') {
             steps {
                 script {
-                    // arti.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
+                    arti.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
                     s3.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@master') _
+@Library('defra-shared@feature/iwtf-2874-s3-interface') _
 def arti = defraArtifactory()
 def s3
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 @Library('defra-shared@master') _
 def arti = defraArtifactory()
+def s3
 
 pipeline {
     agent any
@@ -10,6 +11,16 @@ pipeline {
                     BUILD_TAG = buildTag.updateJenkinsJob()
                     JAR_FILENAME = "rcr_api-${BUILD_TAG}.jar"
                     STAGE_DIR = "${WORKSPACE}/target/dist"
+                    withCredentials([
+                        [
+                            $class: 'AmazonWebServicesCredentialsBinding', 
+                            credentialsId: 'aps-rcr-user',
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]
+                    ]) {
+                        s3 = defraS3('apsldnrcrsrv001')
+                    }
                 }
             }
         }
@@ -37,14 +48,15 @@ pipeline {
         stage('Archive distribution') {
             steps {
                 script {
-                    DIST_FILE = arti.createDistributionFile(STAGE_DIR, "rcr_api")
+                    DIST_FILE = s3.createDistributionFile(STAGE_DIR, "rcr_api")
                 }
             }
         }
         stage('Upload distribution') {
             steps {
                 script {
-                    arti.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
+                    // arti.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
+                    s3.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
                 }
             }
         }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2874

Beginning the process of replacing Artifactory with S3, we use the new S3 interface to create the distribution file and then upload to S3, keeping Artifactory in place until we can completely switch over to S3.