### PR TITLE
Update Ubuntu version used for GH Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tests:
     name: tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
GitHub Actions is deprecating Ubuntu 18.04 for builds so we need to update this.