### PR TITLE
Add CodeArtifact implementation to build job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@master') _
+@Library('defra-shared@iwtf-3523-codeartifact') _
 def arti = defraArtifactory()
 def codeArtifact
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-shared@iwtf-3523-codeartifact') _
+@Library('defra-shared@master') _
 def arti = defraArtifactory()
 def codeArtifact
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('defra-shared@master') _
 def arti = defraArtifactory()
-def s3
+def codeArtifact
 
 pipeline {
     agent any
@@ -13,13 +13,13 @@ pipeline {
                     STAGE_DIR = "${WORKSPACE}/target/dist"
                     withCredentials([
                         [
-                            $class: 'AmazonWebServicesCredentialsBinding', 
+                            $class: 'AmazonWebServicesCredentialsBinding',
                             credentialsId: 'aps-rcr-user',
                             accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         ]
                     ]) {
-                        s3 = defraS3()
+                        codeArtifact = defraCodeArtifact()
                     }
                 }
             }
@@ -48,7 +48,7 @@ pipeline {
         stage('Archive distribution') {
             steps {
                 script {
-                    DIST_FILE = s3.createDistributionFile(STAGE_DIR, "rcr_api")
+                    DIST_FILE = codeArtifact.createDistributionFile(STAGE_DIR, "rcr_api")
                 }
             }
         }
@@ -56,7 +56,7 @@ pipeline {
             steps {
                 script {
                     arti.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
-                    s3.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
+                    codeArtifact.uploadArtifact("rcr-snapshots/api/", "rcr_api", BUILD_TAG, DIST_FILE)
                 }
             }
         }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3595

This is part of the work to switch from Artifactory to CodeArtifact. This PR covers updating the Jenkinsfile to include the CodeArtifact implementation rather than the S3 one since we have changed our plans.